### PR TITLE
Implement utils math package for approximating time series data #44

### DIFF
--- a/pkg/cloud/forecaster/forecaster.go
+++ b/pkg/cloud/forecaster/forecaster.go
@@ -1,0 +1,46 @@
+// There are to common types of prediction
+// 1) one-step ahead prediction
+// 2) long-term prediction (iterative, recursive, direct methods)
+package forecaster
+
+import "errors"
+
+// Least squares with linear approximation
+// http://www.ekonomika-st.ru/drugie/metodi/metodi-prognoz-1-5.html
+//
+// Original function value: yOrig
+// Opproximation function:  yAppr = ax + b
+//
+// F(a, b) = Sum(yOrig[i] - yAppr[i]) -> min
+//
+// Find min of F(a, b):
+// F'(a, b) = 0 =>
+// 	1. dF/da = 0
+// 	2. dF/db = 0
+//
+// params:
+// data - data
+// ah - ahead x prediction
+func forecast(data []float64, ahX int) (float64, error) {
+	var a, b, n, sumY, sumX, sumPow2X, sumXY float64
+
+	n = float64(len(data))
+
+	for i, v := range data {
+		x := float64(i + 1)
+		sumX += x
+		sumY += v
+		sumXY += x * v
+		sumPow2X += x * x
+	}
+
+	if n == 0 || sumX == 0 && sumPow2X == 0 {
+		return 0, errors.New("Forecast: Division by zero")
+	}
+
+	// FIXME: division by zero
+	a = (sumXY - sumX*sumY/n) / (sumPow2X - sumX*sumX/n)
+	b = sumY/n - a*sumX/n
+
+	return a*float64(ahX) + b, nil
+}

--- a/pkg/cloud/forecaster/forecaster_test.go
+++ b/pkg/cloud/forecaster/forecaster_test.go
@@ -1,0 +1,40 @@
+package forecaster
+
+import (
+	"testing"
+)
+
+func Test_forecast(t *testing.T) {
+	testData := []float64{5.3, 6.3, 4.8, 3.8, 3.3}
+	// test 1
+	ahead := 0
+	exp := 6.65
+	got, err := forecast(testData, ahead)
+	if err != nil {
+		t.Error("1) Unexpected division by zero")
+	}
+	if got != exp {
+		t.Errorf("1) Exp %f, Got %f", exp, got)
+	}
+	//test 2
+	ahead = 6
+	exp = 2.75
+	got, err = forecast(testData, ahead)
+	if err != nil {
+		t.Error("2) Unexpected division by zero")
+	}
+	if got != exp {
+		t.Errorf("2) Exp %f, Got %f", exp, got)
+	}
+	// test 3
+	testData = []float64{}
+	got, err = forecast(testData, ahead)
+	if err == nil {
+		t.Error("3) Expected division by zero")
+	}
+	// test 4
+	got, err = forecast(testData, ahead)
+	if err == nil {
+		t.Error("4) Expected division by zero")
+	}
+}


### PR DESCRIPTION
Add method of least squares with lenear approximation. 

This method for both AWS and GCP.

You can read about this method [there](https://en.wikipedia.org/wiki/Least_squares), [there](http://www.ekonomika-st.ru/drugie/metodi/metodi-prognoz-1-5.html) and [there](http://mathprofi.ru/metod_naimenshih_kvadratov.html)